### PR TITLE
Make stdout and stderr optional to support stdio inherit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,17 @@ function spawn(command, args, options, done) {
 
     var out = ''
     var err = ''
-    stdout.setEncoding('utf8')
-    stderr.setEncoding('utf8')
-    stdout.on('data', onoutdata)
-    stderr.on('data', onerrdata)
+    
+    if (stderr) {
+      stderr.setEncoding('utf8')
+      stderr.on('data', onerrdata)
+    }
+    
+    if (stdout) {
+      stdout.setEncoding('utf8')
+      stdout.on('data', onoutdata)
+    }
+    
     child.on('error', onerror)
     child.on('close', onclose)
 
@@ -52,8 +59,8 @@ function spawn(command, args, options, done) {
     }
 
     function cleanup() {
-      stdout.removeListener('data', onoutdata)
-      stderr.removeListener('data', onerrdata)
+      if (stdout) stdout.removeListener('data', onoutdata)
+      if (stderr) stderr.removeListener('data', onerrdata)
       child.removeListener('error', onerror)
       child.removeListener('close', onclose)
     }


### PR DESCRIPTION
This makes stdout and stderr optional as if you pass the options `{ stdio: "inherit" }` then there's no stdout or stderr set on the returned child object.
