### PR TITLE
Cyclic reference on `err`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,13 +41,13 @@ function spawn(command, args, options, done) {
       cleanup()
       if (code === 0 && signal == null) return done(null, out)
 
-      err = new Error('Command failed: ' + command + '\n' + err)
-      err.stdout = out
-      err.stderr = err
-      err.killed = child.killed
-      err.code = code
-      err.signal = signal
-      done(err)
+      var error = new Error('Command failed: ' + command + '\n' + err)
+      error.stdout = out
+      error.stderr = err
+      error.killed = child.killed
+      error.code = code
+      error.signal = signal
+      done(error)
     }
 
     function onoutdata(chunk) {

--- a/test/fixtures/error-bin.js
+++ b/test/fixtures/error-bin.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+console.log('stdout output');
+console.error('stderr output');
+
+throw new Error('Error message');

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -1,4 +1,5 @@
 var co = require('co')
+var path = require('path')
 var readable = require('stream').Readable
 
 var spawn = require('..')
@@ -21,12 +22,24 @@ describe('co-spawn', function () {
     out.should.equal('var a=1;\n')
   }))
 
-  it('should work with errors', () => co(function* () {
+  it('should work with spawn errors', () => co(function* () {
     try {
       yield spawn('laksjdflkajsdf')
       throw new Error('wtf')
     } catch (err) {
       err.code.should.equal('ENOENT')
+    }
+  }))
+
+  it('should work with program errors', () => co(function* () {
+    try {
+      yield spawn(path.join(__dirname, 'fixtures', 'error-bin.js'))
+      throw new Error('wtf')
+    } catch (err) {
+      err.code.should.equal(1)
+      err.stdout.should.equal('stdout output\n')
+      err.stderr.should.containEql('stderr output\n')
+      err.stderr.should.containEql('Error: Error message\n')
     }
   }))
 })


### PR DESCRIPTION
This used to clobber the `err` variable and case a `[Circular]` issue when serializing.

```
Uncaught exception data.
  errData: {
    "stdout": "",
    "stderr": "[Circular]",
    "killed": false,
    "code": null,
    "signal": "SIGSEGV"
  }
```